### PR TITLE
Add villain

### DIFF
--- a/rnRxDB/ios/Podfile.lock
+++ b/rnRxDB/ios/Podfile.lock
@@ -2,19 +2,19 @@ PODS:
   - boost-for-react-native (1.63.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.64.0)
-  - FBReactNativeSpec (0.64.0):
+  - FBLazyVector (0.64.1)
+  - FBReactNativeSpec (0.64.1):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.0)
-    - RCTTypeSafety (= 0.64.0)
-    - React-Core (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - ReactCommon/turbomodule/core (= 0.64.0)
+    - RCTRequired (= 0.64.1)
+    - RCTTypeSafety (= 0.64.1)
+    - React-Core (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - ReactCommon/turbomodule/core (= 0.64.1)
   - Flipper (0.75.1):
     - Flipper-Folly (~> 2.5)
     - Flipper-RSocket (~> 1.3)
   - Flipper-DoubleConversion (1.1.7)
-  - Flipper-Folly (2.5.1):
+  - Flipper-Folly (2.5.3):
     - boost-for-react-native
     - Flipper-DoubleConversion
     - Flipper-Glog
@@ -68,256 +68,256 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTRequired (0.64.0)
-  - RCTTypeSafety (0.64.0):
-    - FBLazyVector (= 0.64.0)
+  - RCTRequired (0.64.1)
+  - RCTTypeSafety (0.64.1):
+    - FBLazyVector (= 0.64.1)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.0)
-    - React-Core (= 0.64.0)
-  - React (0.64.0):
-    - React-Core (= 0.64.0)
-    - React-Core/DevSupport (= 0.64.0)
-    - React-Core/RCTWebSocket (= 0.64.0)
-    - React-RCTActionSheet (= 0.64.0)
-    - React-RCTAnimation (= 0.64.0)
-    - React-RCTBlob (= 0.64.0)
-    - React-RCTImage (= 0.64.0)
-    - React-RCTLinking (= 0.64.0)
-    - React-RCTNetwork (= 0.64.0)
-    - React-RCTSettings (= 0.64.0)
-    - React-RCTText (= 0.64.0)
-    - React-RCTVibration (= 0.64.0)
-  - React-callinvoker (0.64.0)
-  - React-Core (0.64.0):
+    - RCTRequired (= 0.64.1)
+    - React-Core (= 0.64.1)
+  - React (0.64.1):
+    - React-Core (= 0.64.1)
+    - React-Core/DevSupport (= 0.64.1)
+    - React-Core/RCTWebSocket (= 0.64.1)
+    - React-RCTActionSheet (= 0.64.1)
+    - React-RCTAnimation (= 0.64.1)
+    - React-RCTBlob (= 0.64.1)
+    - React-RCTImage (= 0.64.1)
+    - React-RCTLinking (= 0.64.1)
+    - React-RCTNetwork (= 0.64.1)
+    - React-RCTSettings (= 0.64.1)
+    - React-RCTText (= 0.64.1)
+    - React-RCTVibration (= 0.64.1)
+  - React-callinvoker (0.64.1)
+  - React-Core (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.0)
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-Core/Default (= 0.64.1)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.64.0):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
-    - Yoga
-  - React-Core/Default (0.64.0):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
-    - Yoga
-  - React-Core/DevSupport (0.64.0):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.0)
-    - React-Core/RCTWebSocket (= 0.64.0)
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-jsinspector (= 0.64.0)
-    - React-perflogger (= 0.64.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.64.0):
+  - React-Core/CoreModulesHeaders (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.64.0):
+  - React-Core/Default (0.64.1):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
+    - Yoga
+  - React-Core/DevSupport (0.64.1):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.64.1)
+    - React-Core/RCTWebSocket (= 0.64.1)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-jsinspector (= 0.64.1)
+    - React-perflogger (= 0.64.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.64.0):
+  - React-Core/RCTAnimationHeaders (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.64.0):
+  - React-Core/RCTBlobHeaders (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.64.0):
+  - React-Core/RCTImageHeaders (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.64.0):
+  - React-Core/RCTLinkingHeaders (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.64.0):
+  - React-Core/RCTNetworkHeaders (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.64.0):
+  - React-Core/RCTSettingsHeaders (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.64.0):
+  - React-Core/RCTTextHeaders (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.64.0):
+  - React-Core/RCTVibrationHeaders (0.64.1):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.0)
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsiexecutor (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-Core/Default
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
     - Yoga
-  - React-CoreModules (0.64.0):
-    - FBReactNativeSpec (= 0.64.0)
+  - React-Core/RCTWebSocket (0.64.1):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.0)
-    - React-Core/CoreModulesHeaders (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-RCTImage (= 0.64.0)
-    - ReactCommon/turbomodule/core (= 0.64.0)
-  - React-cxxreact (0.64.0):
+    - React-Core/Default (= 0.64.1)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsiexecutor (= 0.64.1)
+    - React-perflogger (= 0.64.1)
+    - Yoga
+  - React-CoreModules (0.64.1):
+    - FBReactNativeSpec (= 0.64.1)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.64.1)
+    - React-Core/CoreModulesHeaders (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-RCTImage (= 0.64.1)
+    - ReactCommon/turbomodule/core (= 0.64.1)
+  - React-cxxreact (0.64.1):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-jsinspector (= 0.64.0)
-    - React-perflogger (= 0.64.0)
-    - React-runtimeexecutor (= 0.64.0)
-  - React-jsi (0.64.0):
+    - React-callinvoker (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-jsinspector (= 0.64.1)
+    - React-perflogger (= 0.64.1)
+    - React-runtimeexecutor (= 0.64.1)
+  - React-jsi (0.64.1):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.64.0)
-  - React-jsi/Default (0.64.0):
+    - React-jsi/Default (= 0.64.1)
+  - React-jsi/Default (0.64.1):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.64.0):
+  - React-jsiexecutor (0.64.1):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-perflogger (= 0.64.0)
-  - React-jsinspector (0.64.0)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-perflogger (= 0.64.1)
+  - React-jsinspector (0.64.1)
   - react-native-get-random-values (1.7.0):
     - React-Core
-  - React-perflogger (0.64.0)
-  - React-RCTActionSheet (0.64.0):
-    - React-Core/RCTActionSheetHeaders (= 0.64.0)
-  - React-RCTAnimation (0.64.0):
-    - FBReactNativeSpec (= 0.64.0)
+  - React-perflogger (0.64.1)
+  - React-RCTActionSheet (0.64.1):
+    - React-Core/RCTActionSheetHeaders (= 0.64.1)
+  - React-RCTAnimation (0.64.1):
+    - FBReactNativeSpec (= 0.64.1)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.0)
-    - React-Core/RCTAnimationHeaders (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - ReactCommon/turbomodule/core (= 0.64.0)
-  - React-RCTBlob (0.64.0):
-    - FBReactNativeSpec (= 0.64.0)
+    - RCTTypeSafety (= 0.64.1)
+    - React-Core/RCTAnimationHeaders (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - ReactCommon/turbomodule/core (= 0.64.1)
+  - React-RCTBlob (0.64.1):
+    - FBReactNativeSpec (= 0.64.1)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.64.0)
-    - React-Core/RCTWebSocket (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-RCTNetwork (= 0.64.0)
-    - ReactCommon/turbomodule/core (= 0.64.0)
-  - React-RCTImage (0.64.0):
-    - FBReactNativeSpec (= 0.64.0)
+    - React-Core/RCTBlobHeaders (= 0.64.1)
+    - React-Core/RCTWebSocket (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-RCTNetwork (= 0.64.1)
+    - ReactCommon/turbomodule/core (= 0.64.1)
+  - React-RCTImage (0.64.1):
+    - FBReactNativeSpec (= 0.64.1)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.0)
-    - React-Core/RCTImageHeaders (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-RCTNetwork (= 0.64.0)
-    - ReactCommon/turbomodule/core (= 0.64.0)
-  - React-RCTLinking (0.64.0):
-    - FBReactNativeSpec (= 0.64.0)
-    - React-Core/RCTLinkingHeaders (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - ReactCommon/turbomodule/core (= 0.64.0)
-  - React-RCTNetwork (0.64.0):
-    - FBReactNativeSpec (= 0.64.0)
+    - RCTTypeSafety (= 0.64.1)
+    - React-Core/RCTImageHeaders (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-RCTNetwork (= 0.64.1)
+    - ReactCommon/turbomodule/core (= 0.64.1)
+  - React-RCTLinking (0.64.1):
+    - FBReactNativeSpec (= 0.64.1)
+    - React-Core/RCTLinkingHeaders (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - ReactCommon/turbomodule/core (= 0.64.1)
+  - React-RCTNetwork (0.64.1):
+    - FBReactNativeSpec (= 0.64.1)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.0)
-    - React-Core/RCTNetworkHeaders (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - ReactCommon/turbomodule/core (= 0.64.0)
-  - React-RCTSettings (0.64.0):
-    - FBReactNativeSpec (= 0.64.0)
+    - RCTTypeSafety (= 0.64.1)
+    - React-Core/RCTNetworkHeaders (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - ReactCommon/turbomodule/core (= 0.64.1)
+  - React-RCTSettings (0.64.1):
+    - FBReactNativeSpec (= 0.64.1)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.0)
-    - React-Core/RCTSettingsHeaders (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - ReactCommon/turbomodule/core (= 0.64.0)
-  - React-RCTText (0.64.0):
-    - React-Core/RCTTextHeaders (= 0.64.0)
-  - React-RCTVibration (0.64.0):
-    - FBReactNativeSpec (= 0.64.0)
+    - RCTTypeSafety (= 0.64.1)
+    - React-Core/RCTSettingsHeaders (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - ReactCommon/turbomodule/core (= 0.64.1)
+  - React-RCTText (0.64.1):
+    - React-Core/RCTTextHeaders (= 0.64.1)
+  - React-RCTVibration (0.64.1):
+    - FBReactNativeSpec (= 0.64.1)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - ReactCommon/turbomodule/core (= 0.64.0)
-  - React-runtimeexecutor (0.64.0):
-    - React-jsi (= 0.64.0)
-  - ReactCommon/turbomodule/core (0.64.0):
+    - React-Core/RCTVibrationHeaders (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - ReactCommon/turbomodule/core (= 0.64.1)
+  - React-runtimeexecutor (0.64.1):
+    - React-jsi (= 0.64.1)
+  - ReactCommon/turbomodule/core (0.64.1):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.0)
-    - React-Core (= 0.64.0)
-    - React-cxxreact (= 0.64.0)
-    - React-jsi (= 0.64.0)
-    - React-perflogger (= 0.64.0)
+    - React-callinvoker (= 0.64.1)
+    - React-Core (= 0.64.1)
+    - React-cxxreact (= 0.64.1)
+    - React-jsi (= 0.64.1)
+    - React-perflogger (= 0.64.1)
   - RNSqlite2 (3.3.0):
     - React-Core
   - Yoga (1.14.0)
@@ -330,7 +330,7 @@ DEPENDENCIES:
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - Flipper (~> 0.75.1)
   - Flipper-DoubleConversion (= 1.1.7)
-  - Flipper-Folly (~> 2.5)
+  - Flipper-Folly (~> 2.5.3)
   - Flipper-Glog (= 0.3.6)
   - Flipper-PeerTalk (~> 0.0.4)
   - Flipper-RSocket (~> 1.3)
@@ -458,11 +458,11 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
-  FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: d272b3699e7d3625347db404406922f57028e0e6
+  FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
+  FBReactNativeSpec: 62e2c90137be6e2a7e48710548c6ca54b8d64a4b
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
-  Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489
+  Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
@@ -471,31 +471,31 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
-  RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
-  RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
-  React: 98eac01574128a790f0bbbafe2d1a8607291ac24
-  React-callinvoker: def3f7fae16192df68d9b69fd4bbb59092ee36bc
-  React-Core: 70a52aa5dbe9b83befae82038451a7df9fd54c5a
-  React-CoreModules: 052edef46117862e2570eb3a0f06d81c61d2c4b8
-  React-cxxreact: c1dc71b30653cfb4770efdafcbdc0ad6d388baab
-  React-jsi: 74341196d9547cbcbcfa4b3bbbf03af56431d5a1
-  React-jsiexecutor: 06a9c77b56902ae7ffcdd7a4905f664adc5d237b
-  React-jsinspector: 0ae35a37b20d5e031eb020a69cc5afdbd6406301
+  RCTRequired: ec2ebc96b7bfba3ca5c32740f5a0c6a014a274d2
+  RCTTypeSafety: 22567f31e67c3e088c7ac23ea46ab6d4779c0ea5
+  React: a241e3dbb1e91d06332f1dbd2b3ab26e1a4c4b9d
+  React-callinvoker: da4d1c6141696a00163960906bc8a55b985e4ce4
+  React-Core: 46ba164c437d7dac607b470c83c8308b05799748
+  React-CoreModules: 217bd14904491c7b9940ff8b34a3fe08013c2f14
+  React-cxxreact: 0090588ae6660c4615d3629fdd5c768d0983add4
+  React-jsi: 5de8204706bd872b78ea646aee5d2561ca1214b6
+  React-jsiexecutor: 124e8f99992490d0d13e0649d950d3e1aae06fe9
+  React-jsinspector: 500a59626037be5b3b3d89c5151bc3baa9abf1a9
   react-native-get-random-values: 237bffb1c7e05fb142092681531810a29ba53015
-  React-perflogger: 9c547d8f06b9bf00cb447f2b75e8d7f19b7e02af
-  React-RCTActionSheet: 3080b6e12e0e1a5b313c8c0050699b5c794a1b11
-  React-RCTAnimation: 3f96f21a497ae7dabf4d2f150ee43f906aaf516f
-  React-RCTBlob: 283b8e5025e7f954176bc48164f846909002f3ed
-  React-RCTImage: 5088a484faac78f2d877e1b79125d3bb1ea94a16
-  React-RCTLinking: 5e8fbb3e9a8bc2e4e3eb15b1eb8bda5fcac27b8c
-  React-RCTNetwork: 38ec277217b1e841d5e6a1fa78da65b9212ccb28
-  React-RCTSettings: 242d6e692108c3de4f3bb74b7586a8799e9ab070
-  React-RCTText: 8746736ac8eb5a4a74719aa695b7a236a93a83d2
-  React-RCTVibration: 0fd6b21751a33cb72fce1a4a33ab9678416d307a
-  React-runtimeexecutor: cad74a1eaa53ee6e7a3620231939d8fe2c6afcf0
-  ReactCommon: cfe2b7fd20e0dbd2d1185cd7d8f99633fbc5ff05
+  React-perflogger: aad6d4b4a267936b3667260d1f649b6f6069a675
+  React-RCTActionSheet: fc376be462c9c8d6ad82c0905442fd77f82a9d2a
+  React-RCTAnimation: ba0a1c3a2738be224a08092fa7f1b444ab77d309
+  React-RCTBlob: f758d4403fc5828a326dc69e27b41e1a92f34947
+  React-RCTImage: ce57088705f4a8d03f6594b066a59c29143ba73e
+  React-RCTLinking: 852a3a95c65fa63f657a4b4e2d3d83a815e00a7c
+  React-RCTNetwork: 9d7ccb8a08d522d71700b4fb677d9fa28cccd118
+  React-RCTSettings: d8aaf4389ff06114dee8c42ef5f0f2915946011e
+  React-RCTText: 809c12ed6b261796ba056c04fcd20d8b90bcc81d
+  React-RCTVibration: 4b99a7f5c6c0abbc5256410cc5425fb8531986e1
+  React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
+  ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
   RNSqlite2: df25f1fefd82da39a3f956504149fb32d23831fb
-  Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
+  Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: cdd47942a7f97a71050009b572a21d07ef392c0a

--- a/rnRxDB/package.json
+++ b/rnRxDB/package.json
@@ -21,7 +21,7 @@
     "pouchdb-adapter-react-native-sqlite": "^3.0.1",
     "pouchdb-mapreduce": "^7.2.2",
     "react": "17.0.1",
-    "react-native": "0.64.0",
+    "react-native": "^0.64.1",
     "react-native-get-random-values": "^1.7.0",
     "react-native-sqlite-2": "^3.3.0",
     "rxdb": "^9.18.0",

--- a/rnRxDB/src/App.tsx
+++ b/rnRxDB/src/App.tsx
@@ -14,24 +14,33 @@ import {
 
 import {Subscription} from 'rxjs';
 import {Hero} from './db/schema/Hero';
+import {Villain} from './db/schema/Villain';
 import useDatabase from './db/useDatabase';
 
 const {width} = Dimensions.get('window');
 
 const App = () => {
   const [heroes, setHeroes] = useState<Hero[]>([]);
-  const [name, setName] = useState('');
+  const [villains, setVillains] = useState<Villain[]>([]);
+  const [heroName, setHeroName] = useState('');
+  const [villainName, setVillainName] = useState('');
   const {db, loading} = useDatabase();
 
   useEffect(() => {
     const subs: Subscription[] = [];
     if (db && !loading) {
-      const sub = db.heroes.find().$.subscribe(_heroes => {
+      const hereos_sub = db.heroes.find().$.subscribe(_heroes => {
         if (_heroes) {
           setHeroes(_heroes);
         }
       });
-      subs.push(sub);
+      subs.push(hereos_sub);
+      const villains_sub = db.villains.find().$.subscribe(_villains => {
+        if (_villains) {
+          setVillains(_villains);
+        }
+      });
+      subs.push(villains_sub);
     }
 
     return () => {
@@ -45,15 +54,29 @@ const App = () => {
 
   const addHero = async () => {
     const color = getRandomColor();
-    if (name !== '') {
-      console.log(`addHero: name: ${name}, color: ${color}`);
-      await db.heroes.insert({name: name, color: color});
-      setName('');
+    if (heroName !== '') {
+      console.log(`addHero: name: ${heroName}, color: ${color}`);
+      await db.heroes.insert({name: heroName, color: color});
+      setHeroName('');
+    }
+  };
+
+  const addVillain = async () => {
+    const color = getRandomColor();
+    if (villainName !== '') {
+      console.log(`addVillain: name: ${villainName}, color: ${color}`);
+      await db.villains.insert({name: villainName, color: color});
+      setVillainName('');
     }
   };
 
   const removeHero = async (hero_name: string) => {
     const found = await db.heroes.find().where('name').eq(hero_name);
+    await found.remove();
+  };
+
+  const removeVillain = async (villain_name: string) => {
+    const found = await db.villains.find().where('name').eq(villain_name);
     await found.remove();
   };
 
@@ -70,7 +93,6 @@ const App = () => {
     <SafeAreaView style={styles.topContainer}>
       <StatusBar backgroundColor="#55C7F7" barStyle="light-content" />
       <Text style={styles.title}>Add your favorite hero!</Text>
-
       <ScrollView style={styles.heroesList}>
         <View style={styles.card}>
           <TouchableOpacity onPress={addHero}>
@@ -81,8 +103,8 @@ const App = () => {
           </TouchableOpacity>
           <TextInput
             style={styles.input}
-            value={name}
-            onChangeText={text => setName(text)}
+            value={heroName}
+            onChangeText={text => setHeroName(text)}
           />
         </View>
         {heroes.length === 0 && <Text>No heroes to display ...</Text>}
@@ -100,6 +122,45 @@ const App = () => {
               <Text style={styles.heroName}>{hero.name}</Text>
             </View>
             <TouchableOpacity onPress={() => removeHero(hero.name)}>
+              <Image
+                style={styles.plusImage}
+                source={require('../assets/minus.png')}
+              />
+            </TouchableOpacity>
+          </View>
+        ))}
+      </ScrollView>
+
+      <Text style={styles.title}>Add your favorite villain!</Text>
+      <ScrollView style={styles.heroesList}>
+        <View style={styles.card}>
+          <TouchableOpacity onPress={addVillain}>
+            <Image
+              style={styles.plusImage}
+              source={require('../assets/add.png')}
+            />
+          </TouchableOpacity>
+          <TextInput
+            style={styles.input}
+            value={villainName}
+            onChangeText={text => setVillainName(text)}
+          />
+        </View>
+        {villains.length === 0 && <Text>No villains to display ...</Text>}
+        {villains.map((villain, index) => (
+          <View style={styles.card} key={index}>
+            <View style={styles.row}>
+              <View
+                style={[
+                  styles.colorBadge,
+                  {
+                    backgroundColor: villain.color,
+                  },
+                ]}
+              />
+              <Text style={styles.heroName}>{villain.name}</Text>
+            </View>
+            <TouchableOpacity onPress={() => removeVillain(villain.name)}>
               <Image
                 style={styles.plusImage}
                 source={require('../assets/minus.png')}

--- a/rnRxDB/src/db/schema/Hero.tsx
+++ b/rnRxDB/src/db/schema/Hero.tsx
@@ -3,6 +3,7 @@ import {RxCollection, RxDocument, RxJsonSchema} from 'rxdb';
 export type Hero = {
   name: string;
   color: string;
+  type: string;
 };
 
 export type HeroDocument = RxDocument<Hero>;
@@ -22,6 +23,10 @@ export const HeroSchema: RxJsonSchema<Hero> = {
     color: {
       type: 'string',
     },
+    type: {
+      type: 'string',
+      default: 'Hero',
+    },
   },
-  required: ['color'],
+  required: ['color', 'type'],
 };

--- a/rnRxDB/src/db/schema/Villain.tsx
+++ b/rnRxDB/src/db/schema/Villain.tsx
@@ -1,0 +1,30 @@
+import {RxCollection, RxDocument, RxJsonSchema} from 'rxdb';
+
+export type Villain = {
+  name: string;
+  color: string;
+};
+
+export type VillainDocument = RxDocument<Villain>;
+
+export type VillainCollection = RxCollection<Villain>;
+
+export const VillainSchema: RxJsonSchema<Villain> = {
+  version: 0,
+  title: 'villain schema',
+  description: 'describes a simple villain',
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      primary: true,
+    },
+    color: {
+      type: 'string',
+    },
+  },
+  attachments: {
+    encrypted: false,
+  },
+  required: ['color'],
+};

--- a/rnRxDB/src/db/schema/Villain.tsx
+++ b/rnRxDB/src/db/schema/Villain.tsx
@@ -3,6 +3,7 @@ import {RxCollection, RxDocument, RxJsonSchema} from 'rxdb';
 export type Villain = {
   name: string;
   color: string;
+  type: string;
 };
 
 export type VillainDocument = RxDocument<Villain>;
@@ -22,9 +23,13 @@ export const VillainSchema: RxJsonSchema<Villain> = {
     color: {
       type: 'string',
     },
+    type: {
+      type: 'string',
+      default: 'Villain',
+    },
   },
   attachments: {
     encrypted: false,
   },
-  required: ['color'],
+  required: ['color', 'type'],
 };

--- a/rnRxDB/src/db/useDatabase.tsx
+++ b/rnRxDB/src/db/useDatabase.tsx
@@ -66,7 +66,7 @@ const useDatabase = () => {
     const create_db = async () => {
       setLoading(true);
       try {
-        // await removeRxDatabase(dbName, 'react-native-sqlite');
+        await removeRxDatabase(dbName, 'react-native-sqlite');
         const rxdb = await createRxDatabase<Collections>({
           name: dbName,
           adapter: 'react-native-sqlite',
@@ -80,8 +80,8 @@ const useDatabase = () => {
             schema: VillainSchema,
           },
         });
-        configureSync('heroes');
-        configureSync('villains');
+        // configureSync('heroes');
+        // configureSync('villains');
         setDb(rxdb);
       } catch (err) {
         setError(err);
@@ -89,10 +89,11 @@ const useDatabase = () => {
       }
       setLoading(false);
     };
-    if (!db && !loading) {
-      create_db();
-    }
-  }, [db, loading]);
+    create_db();
+    // if (!db && !loading) {
+    //   create_db();
+    // }
+  }, []);
 
   return {db, loading, error};
 };

--- a/rnRxDB/src/db/useDatabase.tsx
+++ b/rnRxDB/src/db/useDatabase.tsx
@@ -31,14 +31,20 @@ const useDatabase = () => {
   const [error, setError] = useState();
 
   useEffect(() => {
-    const configureSync = (collection: string) => {
-      const replicationState = db[collection].sync({
+    const configureSync = (
+      collection: string,
+      type: string,
+      database: RxDatabase<Collections>,
+    ) => {
+      console.log('name: ', collection);
+      const replicationState = database[collection].sync({
         remote: syncUrl + dbName + '/',
         options: {
           live: true,
           retry: true,
         },
         waitForLeadership: false,
+        query: database[collection].find().where('type').eq(type),
       });
       replicationState.change$.subscribe(change =>
         console.log(`${collection} change: `, change),
@@ -80,8 +86,8 @@ const useDatabase = () => {
             schema: VillainSchema,
           },
         });
-        // configureSync('heroes');
-        // configureSync('villains');
+        configureSync('heroes', 'Hero', rxdb);
+        configureSync('villains', 'Villain', rxdb);
         setDb(rxdb);
       } catch (err) {
         setError(err);
@@ -90,9 +96,6 @@ const useDatabase = () => {
       setLoading(false);
     };
     create_db();
-    // if (!db && !loading) {
-    //   create_db();
-    // }
   }, []);
 
   return {db, loading, error};

--- a/rnRxDB/src/db/useDatabase.tsx
+++ b/rnRxDB/src/db/useDatabase.tsx
@@ -1,5 +1,10 @@
 import {useEffect, useState} from 'react';
-import {addRxPlugin, createRxDatabase, RxDatabase} from 'rxdb';
+import {
+  addRxPlugin,
+  createRxDatabase,
+  removeRxDatabase,
+  RxDatabase,
+} from 'rxdb';
 import SQLite from 'react-native-sqlite-2';
 import SQLiteAdapterFactory from 'pouchdb-adapter-react-native-sqlite';
 import {HeroCollection, HeroSchema} from './schema/Hero';
@@ -61,6 +66,7 @@ const useDatabase = () => {
     const create_db = async () => {
       setLoading(true);
       try {
+        // await removeRxDatabase(dbName, 'react-native-sqlite');
         const rxdb = await createRxDatabase<Collections>({
           name: dbName,
           adapter: 'react-native-sqlite',

--- a/rnRxDB/src/db/useDatabase.tsx
+++ b/rnRxDB/src/db/useDatabase.tsx
@@ -3,6 +3,7 @@ import {addRxPlugin, createRxDatabase, RxDatabase} from 'rxdb';
 import SQLite from 'react-native-sqlite-2';
 import SQLiteAdapterFactory from 'pouchdb-adapter-react-native-sqlite';
 import {HeroCollection, HeroSchema} from './schema/Hero';
+import {VillainCollection, VillainSchema} from './schema/Villain';
 
 const SQLiteAdapter = SQLiteAdapterFactory(SQLite);
 
@@ -11,9 +12,10 @@ addRxPlugin(require('pouchdb-adapter-http'));
 
 type Collections = {
   heroes: HeroCollection;
+  villains: VillainCollection;
 };
 
-const dbName = 'heroes';
+const dbName = 'everything';
 const syncUrl = 'http://admin:password@localhost:5984/';
 
 console.log('remote db: ', syncUrl + dbName);
@@ -24,6 +26,38 @@ const useDatabase = () => {
   const [error, setError] = useState();
 
   useEffect(() => {
+    const configureSync = (collection: string) => {
+      const replicationState = db[collection].sync({
+        remote: syncUrl + dbName + '/',
+        options: {
+          live: true,
+          retry: true,
+        },
+        waitForLeadership: false,
+      });
+      replicationState.change$.subscribe(change =>
+        console.log(`${collection} change: `, change),
+      );
+      replicationState.docs$.subscribe(docData =>
+        console.log(`${collection} doc: `, docData),
+      );
+      replicationState.denied$.subscribe(docData =>
+        console.log(`${collection} denied: `, docData),
+      );
+      replicationState.active$.subscribe(active =>
+        console.log(`${collection} active: `, active),
+      );
+      replicationState.alive$.subscribe(alive =>
+        console.log(`${collection} alive: `, alive),
+      );
+      replicationState.complete$.subscribe(completed =>
+        console.log(`${collection} completed: `, completed),
+      );
+      replicationState.error$.subscribe(err =>
+        console.dir(`${collection} error: `, err),
+      );
+    };
+
     const create_db = async () => {
       setLoading(true);
       try {
@@ -36,34 +70,12 @@ const useDatabase = () => {
           heroes: {
             schema: HeroSchema,
           },
-        });
-        const replicationState = rxdb.heroes.sync({
-          remote: syncUrl + dbName + '/',
-          options: {
-            live: true,
-            retry: true,
+          villains: {
+            schema: VillainSchema,
           },
-          waitForLeadership: false,
         });
-        replicationState.change$.subscribe(change =>
-          console.log('change: ', change),
-        );
-        replicationState.docs$.subscribe(docData =>
-          console.log('doc: ', docData),
-        );
-        replicationState.denied$.subscribe(docData =>
-          console.log('denied: ', docData),
-        );
-        replicationState.active$.subscribe(active =>
-          console.log('active: ', active),
-        );
-        replicationState.alive$.subscribe(alive =>
-          console.log('alive: ', alive),
-        );
-        replicationState.complete$.subscribe(completed =>
-          console.log('completed: ', completed),
-        );
-        replicationState.error$.subscribe(err => console.dir('error: ', err));
+        configureSync('heroes');
+        configureSync('villains');
         setDb(rxdb);
       } catch (err) {
         setError(err);

--- a/rnRxDB/yarn.lock
+++ b/rnRxDB/yarn.lock
@@ -6715,10 +6715,10 @@ react-native-sqlite-2@^3.3.0:
     lodash.zipobject "^4.1.3"
     websql "^2.0.0"
 
-react-native@0.64.0:
-  version "0.64.0"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.64.0.tgz#c3bde5b638bf8bcf12bae6e094930d39cb942ab7"
-  integrity sha512-8dhSHBthgGwAjU+OjqUEA49229ThPMQH7URH0u8L0xoQFCnZO2sZ9Wc6KcbxI0x9KSmjCMFFZqRe3w3QsRv64g==
+react-native@^0.64.1:
+  version "0.64.1"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.64.1.tgz#cd38f5b47b085549686f34eb0c9dcd466f307635"
+  integrity sha512-jvSj+hNAfwvhaSmxd5KHJ5HidtG0pDXzoH6DaqNpU74g3CmAiA8vuk58B5yx/DYuffGq6PeMniAcwuh3Xp4biQ==
   dependencies:
     "@jest/create-cache-key-function" "^26.5.0"
     "@react-native-community/cli" "^5.0.1-alpha.0"


### PR DESCRIPTION
This PR adds a Villain portion to the example app to demonstrate how to use multiple collections for a single db instance using RxDB alone without any other libs.

To run and test:
- Open 3 terminals in the <repo_location>/battalion-examples/rnrxdb directory
- Terminal 1: run `yarn ios --simulator "iPhone 12"`
- Terminal 2: run `yarn ios --simulator "iPhone 12 Pro"`
- Terminal 3: run `yarn server:start` to start couchdb container and `yarn server:stop` when finished